### PR TITLE
Update Pydantic to version 2.4.2

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
-        django: [32,40,41,main]
+        python: ["3.10", "3.11", "3.12"]
+        django: [32,42,50,main]
+        exclude:
+          - python: "3.11"
+            django: "32"
+          - python: "3.12"
+            django: "32"
+          - python: "3.12"
+            django: "42"
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2023-02-17
+
+- Drop support for Python < 3.10
+- Drop support for Pydantic < 2
+
 ## [0.10.0] - 2023-02-17
 
 - Improve admin list view to include date filters and value search [#8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [{ include = "csp" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "^3.2 || ^4.0"
-pydantic = "^1"
+pydantic = "*"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csp-plus"
-version = "0.10.0"
+version = "3.0.0"
 description = "CSP tracking and violation report endpoint."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -19,8 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10,3.11}-django{32,41,42,main}
+envlist = fmt, lint, mypy, checks, py{3.10,3.11}-django{32,41,42,main}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, checks, py{3.10,3.11}-django{32,41,42,main}
+envlist =
+    fmt, lint, mypy, checks,
+    py{3.10}-django{32,42,50,main}
+    py{3.11}-django{42,50,main}
+    py{3.12}-django{50,main}
 
 [testenv]
 deps =


### PR DESCRIPTION
Upgrades `Pydantic` to version `2.4.2` and updates the code [accordingly](https://docs.pydantic.dev/latest/migration/).
Closes https://github.com/yunojuno/django-csp-plus/issues/9