### PR TITLE
Misc: Django 5.2 updates

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -66,6 +66,8 @@ jobs:
         exclude:
           - python: "3.10"
             django: "main"
+          - python: "3.11"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -62,14 +62,10 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12"]
         # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.10"
             django: "main"
-          - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 3.2.0 - 2024-06-17
 
-- Add support for Django 5.2
 - Drop support for Django < 4.2
+- Add support for Django 5.2
+- Fix type annotation for status_code field in ReportData model
+- Update development tooling for compatibility with current versions
 
 ## 3.1.1 - 2024-01-06
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.2.0 - 2024-06-17
+
+- Add support for Django 5.2
+- Drop support for Django < 4.2
+
 ## 3.1.1 - 2024-01-06
 
 - Fix issue with 'none' in directives

--- a/README
+++ b/README
@@ -10,6 +10,11 @@ with a couple of alterations:
 
 The `nonce` pattern has been lifted directly.
 
+## Requirements
+
+- Django 4.2 or higher
+- Python 3.10 or higher
+
 ## History
 
 The original reason for forking this from the original was the desire to

--- a/README
+++ b/README
@@ -15,6 +15,13 @@ The `nonce` pattern has been lifted directly.
 - Django 4.2 or higher
 - Python 3.10 or higher
 
+## Changes in 3.2.0
+
+- Dropped support for Django versions below 4.2
+- Added support for Django 5.2
+- Fixed type annotation in models.py for status_code field
+- Updated tooling to work with latest versions of development tools
+
 ## History
 
 The original reason for forking this from the original was the desire to

--- a/csp/models.py
+++ b/csp/models.py
@@ -34,7 +34,7 @@ class ReportData(BaseModel):
     original_policy: str | None = Field(None, alias="original-policy")
     referrer: str | None = Field(None, alias="referrer")
     script_sample: str | None = Field(None, alias="script-sample")
-    status_code: str | None = Field(0, alias="status-code")
+    status_code: str | None = Field("0", alias="status-code")
 
     @field_validator("document_uri", "blocked_uri")
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csp-plus"
-version = "3.1.1"
+version = "3.2.0"
 description = "CSP tracking and violation report endpoint."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,11 +12,9 @@ documentation = "https://github.com/yunojuno/django-csp-plus"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -28,7 +26,7 @@ packages = [{ include = "csp" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 pydantic = "*"
 
 [tool.poetry.group.test.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff csp
+    ruff check csp
 
 [testenv:mypy]
 description = Python source code type hints (mypy)

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,9 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{310}
-    django40-py{310}
-    django41-py{310,311}
     django42-py{310,311}
     django50-py{310,311,312}
+    django52-py{310,311,312}
     djangomain-py{311,312}
 
 [testenv]
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
This PR updates the compatibility requirements for django-csp-plus by dropping support for older Django versions and ensuring compatibility with Django 5.2.

## Changes

1. Dropped support for Django < 4.2: Removed Django 3.2, 4.0, and 4.1 from all configurations
2. Added Django 5.2 support, updated build matrix and classifiers
3. Updated dependency requirements from ^3.2 || ^4.0 || ^5.0 to ^4.2 || ^5.0
4. Updated GitHub Actions workflow: Removed obsolete test configurations and added Django 5.2 testing
5. Fix type annotation for `status_code` field in `ReportData` model

### Documentation updates:

1. Added Requirements section to README
2. Updated CHANGELOG with version 3.2.0
3. Version bump: Updated to version 3.2.0

## Reason for Changes

Focusing support on recent Django LTS versions (4.2) and newer enables us to maintain a more streamlined codebase and ensure compatibility with current security practices and features.