### PR TITLE
Django 6.0 & Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -45,10 +45,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -60,14 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.12", "3.13"]
         # build LTS version, next version, HEAD
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README
+++ b/README
@@ -12,8 +12,8 @@ The `nonce` pattern has been lifted directly.
 
 ## Requirements
 
-- Django 4.2 or higher
-- Python 3.10 or higher
+- Python 3.12+
+- Django 5.2-6.0
 
 ## Changes in 3.2.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csp-plus"
-version = "3.2.0"
+version = "3.3.0"
 description = "CSP tracking and violation report endpoint."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,21 +12,19 @@ documentation = "https://github.com/yunojuno/django-csp-plus"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "csp" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^4.2 || ^5.0"
+python = "^3.12"
+django = ">=5.2,<7.0"
 pydantic = "*"
 
 [tool.poetry.group.test.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,10 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django42-py{310,311}
-    django50-py{310,311,312}
-    django52-py{310,311,312}
-    djangomain-py{311,312}
+    ; https://docs.djangoproject.com/en/6.0/releases/
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -15,9 +14,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)